### PR TITLE
Handle all Mac operating systems

### DIFF
--- a/src/main/scala/translate/GitMessage2Csv.scala
+++ b/src/main/scala/translate/GitMessage2Csv.scala
@@ -82,9 +82,9 @@ trait GitMessage2Csv extends KeyValueParser with FileReader with WrappedPrintWri
     val pr = System.getProperties()
     // Windows / Linux / MacOS / Other
     pr.get("os.name") match {
-      case "Linux" => executeCommand(s"./git-retrieve.sh $projectDir $gitCloneRef $gitCommitRef")
-      case "MacOS" => executeCommand(s"./git-retrieve.sh $projectDir $gitCloneRef $gitCommitRef")
-      case "Windows" => println("Only Bash script created so far. Windows bat file will be added, or please feel free to add it! :)")
+      case (linux: String) if(linux.contains("Linux")) => executeCommand(s"./git-retrieve.sh $projectDir $gitCloneRef $gitCommitRef")
+      case (windows: String) if(windows.contains("Windows")) => println("Only Bash script created so far. Windows bat file will be added, or please feel free to add it! :)")
+      case (macOS: String) if(macOS.contains("Mac")) => executeCommand(s"./git-retrieve.sh $projectDir $gitCloneRef $gitCommitRef")
       case _ => println("Only Bash script created so far. ")
     }
   }


### PR DESCRIPTION
PR is to handle all Mac operating systems when attempting to query the `System.getProperties().get("os.name")` on `fetchGitFiles()`. As we can see from the below not all versions Mac OS.name are defined as "MacOS" from the previous implementation. 

<img width="336" alt="screen shot 2018-07-04 at 15 20 47" src="https://user-images.githubusercontent.com/35524506/42282739-68d3ae16-7f9f-11e8-8023-0ba458afffea.png">

The bug fix inside of this PR does a check to see if any OS name contains the String 'Mac' and performs its operation when asserted true. The same logic has been added for the Linux and Windows implementations.